### PR TITLE
chore(ci): fix gha set-output command

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -37,12 +37,12 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      
+
       - name: Install JS dependencies
         run: yarn install
-        
+
       - name: Build.
         run: yarn build
-        
+
       - name: Linter.
-        run: yarn lint:ci    
+        run: yarn lint:ci


### PR DESCRIPTION
GitHub is going to deprecate `save-state` and `set-output` commands. [More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR adjusts GHA workflow to use new syntax.

Part of https://github.com/paritytech/ci_cd/issues/805